### PR TITLE
Update Server.js's logged output to automatically match server hostname

### DIFF
--- a/App/backend/server.js
+++ b/App/backend/server.js
@@ -25,7 +25,10 @@ app.use("/api/people", require("./routes/peopleRoutes"));
 // End Connect DB Activity Code.
 
 
+const os = require("os");
+const hostname = os.hostname();
+
 app.listen(PORT, () => {
-  // Change this text to whatever FLIP server you're on
-  console.log(`Server running:  http://flip3.engr.oregonstate.edu:${PORT}...`);
+  // flip server should automatically match whatever server you're on 
+  console.log(`Server running:  http://${hostname}:${PORT}...`);
 });


### PR DESCRIPTION
Not sure if this is allowed, feel free to reject if it is not. I am currently in the summer term of CS 340 and while troubleshooting why my frontend & backend were not speaking with each other I realized I was dependent on the hard-coded host name in the console's logged output. 

Based on the following StackOverflow post, I updated server.js in the backend folder to automatically update the console log message to match whatever flip server you are running the code on, as in my case I was running on flip4 instead of flip3.

https://stackoverflow.com/questions/20553554/node-js-return-hostname